### PR TITLE
Clean_up() on KeyboardInterrupt -- shut down gracefully.

### DIFF
--- a/take_in.py
+++ b/take_in.py
@@ -7,7 +7,7 @@ Takes in all ballots placed in tray.
 
 Driven by the paper feeder of the HP Deskjet 1000 J110.
 """
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 # Output pins.
 MOTOR_ENABLE = 17
@@ -26,22 +26,27 @@ def setup():
     GPIO.setmode(GPIO.BCM)
 
     GPIO.setup(MOTOR_ENABLE, GPIO.OUT)
+    pwm = GPIO.PWM(MOTOR_ENABLE, 120)
+    pwm.start(0)
+
     GPIO.setup(MOTOR_FORWARD, GPIO.OUT)
     GPIO.setup(MOTOR_BACKWARD, GPIO.OUT)
 
     GPIO.setup(HALFWAY_TRIGGER, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-def take_in():
+    return pwm
+
+def take_in(pwm):
     """Take in all ballots."""
     tray_empty = False
     timeout = time.time() + 1   # One second from now.
 
     logging.info("Taking in a sheet...")
 
-    logging.info("Rolling forward...")
+    logging.debug("Rolling forward...")
     before_halfway = GPIO.input(HALFWAY_TRIGGER) # True if trigger depressed.
     while before_halfway:
-        GPIO.output(MOTOR_ENABLE, True)
+        pwm.ChangeDutyCycle(100)
         GPIO.output(MOTOR_FORWARD, True)
         GPIO.output(MOTOR_BACKWARD, False)
 
@@ -52,12 +57,12 @@ def take_in():
 
         before_halfway = GPIO.input(HALFWAY_TRIGGER) # True if trigger depressed.
 
-    logging.info("Rolling backward...")
+    logging.debug("Rolling backward...")
     time.sleep(.1)
     if not tray_empty:
-        slow_motor()
+        slow_motor(pwm)
     while not before_halfway:
-        GPIO.output(MOTOR_ENABLE, True)
+        pwm.ChangeDutyCycle(100)
         GPIO.output(MOTOR_FORWARD, False)
         GPIO.output(MOTOR_BACKWARD, True)
 
@@ -65,37 +70,37 @@ def take_in():
     
     time.sleep(.1)
     if not tray_empty:
-        take_in()
+        take_in(pwm)
 
-def slow_motor():
+def slow_motor(pwm):
     """Slow down motor to make accept or reject decision."""
+    logging.debug('Slowing motor.')
+    pwm.ChangeDutyCycle(40)
     GPIO.output(MOTOR_FORWARD, False)
     GPIO.output(MOTOR_BACKWARD, True)
-    p = GPIO.PWM(MOTOR_ENABLE, 120)
-    p.start(40)
     time.sleep(3)
-    p.stop()
 
 
-
-def clean_up():
+def clean_up(pwm):
     """Roll backward to open tray, then shut down pins."""
-    GPIO.setup(MOTOR_ENABLE, GPIO.OUT)
-    GPIO.output(MOTOR_ENABLE, True)
+    logging.info('Cleaning up.')
+    pwm.ChangeDutyCycle(100)
     GPIO.output(MOTOR_FORWARD, False)
     GPIO.output(MOTOR_BACKWARD, True)
     time.sleep(1)
 
+    pwm.stop()
     GPIO.cleanup()
 
 def main():
-    setup()
-    take_in()
-    clean_up()
+    pwm = setup()
+    take_in(pwm)
+    clean_up(pwm)
 
 if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
         logging.info('Keyboard interrupt.')
-        clean_up()
+        pwm = setup()
+        clean_up(pwm)

--- a/take_in.py
+++ b/take_in.py
@@ -32,7 +32,7 @@ def setup():
 def take_in():
     """Take in all ballots."""
     tray_empty = False
-    timeout = time.time() + 1   # One seconds from now.
+    timeout = time.time() + 1   # One second from now.
 
     print "Taking in a sheet..."
 
@@ -67,7 +67,8 @@ def take_in():
 def slow_motor():
     """Slow down motor to make accept or reject decision."""
     GPIO.output(MOTOR_FORWARD, False)
-    p = GPIO.PWM(MOTOR_BACKWARD, 120)
+    GPIO.output(MOTOR_BACKWARD, True)
+    p = GPIO.PWM(MOTOR_ENABLE, 120)
     p.start(40)
     time.sleep(3)
     p.stop()

--- a/take_in.py
+++ b/take_in.py
@@ -88,4 +88,7 @@ def main():
     clean_up()
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        cleanup()

--- a/take_in.py
+++ b/take_in.py
@@ -1,5 +1,4 @@
 import RPi.GPIO as GPIO
-
 import time
 
 """
@@ -83,8 +82,10 @@ def clean_up():
 
     GPIO.cleanup()
 
-# Main execution.
-setup()
-take_in()
-clean_up()
+def main():
+    setup()
+    take_in()
+    clean_up()
 
+if __name__ == '__main__':
+    main()

--- a/take_in.py
+++ b/take_in.py
@@ -91,4 +91,4 @@ if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
-        cleanup()
+        clean_up()


### PR DESCRIPTION
Can't figure out why `clean_up()` isn't running properly if the keyboard interrupt happens during the `slow_down()` phase. `time.sleep(1)` is invoked, but the motor just comes to a stop.

/cc @luejerry 
